### PR TITLE
Pick up only those tags starting with a 'v'

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -12,5 +12,5 @@ function sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
-versions=$(eval $cmd | grep -oE "tag_name\": *\".{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
+versions=$(eval $cmd | grep -oE "tag_name\": *\"v.*.{1,15}\"," | sed 's/tag_name\": *\"v//;s/\",//' | sort_versions)
 echo $versions


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

The list-all command is picking up an accidental tag which doesn't have the `v` prefix.

```sh
❯ bin/list-all | | grep "5\.10\.1"
5.10.1
"5.10.1.z'
```

This breaks the latest-all command

```sh
❯ asdf latest --all | grep pluto
pluto	"5.10.1.z	missing
```


### What's the goal of this PR?

Fix the above

### What changes did you make?

Add a check for to ensure the tag starts with a 'v'
