### PR TITLE
detect machine arch

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,8 @@ install_pluto() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  local arch=$(uname -m | sed 's/aarch64/arm64/g; s/x86_64/amd64/g')
+  local platform="$(uname | tr '[:upper:]' '[:lower:]')_${arch}"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/pluto"
   local download_url=$(get_download_url $version $platform)


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Current version hard codes to `amd64` architecture.  This MR auto detect the architecture to better support `arm64` based systems such as Apple M1/M2 CPUs and Linux on ARM64 chips

### What changes did you make?
Modified 2 lines auto detect machine architecture via `uname -m`

### What alternative solution should we consider, if any?
None
