### PR TITLE
detect machine arch

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -7,7 +7,8 @@ install_pluto() {
   local install_type=$1
   local version=$2
   local install_path=$3
-  local platform="$(uname | tr '[:upper:]' '[:lower:]')_amd64"
+  local arch=$(uname -m | sed 's/aarch64/arm64/g; s/x86_64/amd64/g')
+  local platform="$(uname | tr '[:upper:]' '[:lower:]')_${arch}"
   local bin_install_path="$install_path/bin"
   local binary_path="$bin_install_path/pluto"
   local download_url=$(get_download_url $version $platform)


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Current version hard codes `amd64` version. This PR auto detect machine architecture to better support `arm64` machines such as Apple M1 and Linux on arm64 chips 

### What changes did you make?
Detect machine arch via `uname -m` to set the download the appropriate `pluto` binary for that architecture

### What alternative solution should we consider, if any?
None
